### PR TITLE
fix(links): permissive combine strategy

### DIFF
--- a/internal/config/fixtures/templates.yaml
+++ b/internal/config/fixtures/templates.yaml
@@ -13,6 +13,7 @@ links:
   # This is configured in internal/config/config_test.go
   # want: fo/fr:.ln-config.yaml@ -> to/tr:.ln-config.yaml@
   - from: "{{ .Config.Source.Path }}"
+    to: "{{ .Config.Source.Path }}"
 
   # want: owner/current_repo:fp@ -> to/tr:tp@
   - from:

--- a/internal/config/links.go
+++ b/internal/config/links.go
@@ -72,21 +72,43 @@ func (c *Config) parseLink(raw RawLink) (Links, error) {
 
 func combineLinks(froms, tos []github.File) Links {
 	if len(froms) == 0 {
-		log.Warn("Found no `from`, make sure you reference one.")
-
-		return Links{}
+		return combineLinksNoFrom(tos)
 	}
 
-	useFrom := len(tos) == 0
+	if len(tos) == 0 {
+		return combineLinksNoTos(froms)
+	}
 
+	return combineLinksAll(froms, tos)
+}
+
+func combineLinksNoFrom(tos []github.File) Links {
+	links := Links{}
+
+	for _, to := range tos {
+		links = append(links, &Link{From: github.File{}, To: to})
+	}
+
+	return links
+}
+
+func combineLinksNoTos(froms []github.File) Links {
 	links := Links{}
 
 	for _, from := range froms {
-		if useFrom {
-			// TODO: inherit the `ref` as well?
-			tos = []github.File{{Path: from.Path}}
-		}
+		links = append(links, &Link{
+			From: from,
+			To:   github.File{},
+		})
+	}
 
+	return links
+}
+
+func combineLinksAll(froms, tos []github.File) Links {
+	links := Links{}
+
+	for _, from := range froms {
 		for _, to := range tos {
 			links = append(links, &Link{From: from, To: to})
 		}

--- a/internal/config/links_test.go
+++ b/internal/config/links_test.go
@@ -36,7 +36,10 @@ func TestCombineLinks(t *testing.T) {
 				mkFile("0"),
 				mkFile("1"),
 			},
-			want: Links{},
+			want: Links{
+				mkLink("", "0"),
+				mkLink("", "1"),
+			},
 		},
 
 		{
@@ -46,8 +49,8 @@ func TestCombineLinks(t *testing.T) {
 			},
 			tos: []github.File{},
 			want: Links{
-				mkLink("0", "0"),
-				mkLink("1", "1"),
+				mkLink("0", ""),
+				mkLink("1", ""),
 			},
 		},
 


### PR DESCRIPTION
This changes the way links.combine works in the following ways:
- if `tos` is empty, the result is a list of links without To;
- if `froms` is empty, the result is a list of links without From;
- don't inherit the `tos` from the `froms` if missing
- otherwise, zip the two

This means that now, the `Default` values take precedence over the `from` for a link. This might not be ideal, but can be fixed later.

It also means, that `Defaults` without a `From` (e.g. only setting the `To`) will work.

A better solution might be to have `defaults` and `overrides` as global settings. `defaults` being applied _before_ the combination, `overrides`, after.